### PR TITLE
feat: Target .NET Standard 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ be launched, and for the WebDriver Bidi websocket to already be open and availab
 it is the user's responsibility to know what the URL of the websocket connection is to initiate a session.
 
 ## Getting Started
-The library is built using .NET 6. There are no plans at present to support earlier versions of .NET.
-Future versions of .NET will be supported when [a new LTS version](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) is released. The next LTS version of .NET is scheduled to be .NET 8, released in November, 2023.
+The library is built to support .NETStandard 2.0. This should allow the widest usage of the library across
+the largest number of framework versions, including .NET Framework, .NET Core, and .NET 5 and higher.
 
 To build the library, after cloning the repository, execute the following in a terminal window
 in the root of your clone:

--- a/src/WebDriverBidi.Client/Action.cs
+++ b/src/WebDriverBidi.Client/Action.cs
@@ -37,7 +37,7 @@ public class Action
     /// <exception cref="WebDriverBidiException">Thrown if this action cannot be converted to the specified type.</exception>
     public T AsActionType<T>()
     {
-        if (!this.action.GetType().IsAssignableTo(typeof(T)))
+        if (!typeof(T).IsAssignableFrom(this.action.GetType()))
         {
             throw new WebDriverBidiException($"Object cannot be cast to type {typeof(T)}");
         }

--- a/src/WebDriverBidi.Client/WebDriverBidi.Client.csproj
+++ b/src/WebDriverBidi.Client/WebDriverBidi.Client.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>11</LangVersion>
     <RootNamespace>WebDriverBidi.Client</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -18,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebDriverBidi.Demo/Program.cs
+++ b/src/WebDriverBidi.Demo/Program.cs
@@ -13,7 +13,7 @@ using WebDriverBidi.Session;
 // Path to the directory containing the browser launcher executables.
 // We use the WebDriver Classic browser drivers (chromedriver, geckodriver, etc.)
 // as browser launchers.
-string browserLauncherDirectory = "/Users/james.evans/Downloads";
+string browserLauncherDirectory = string.Empty;
 
 // The level at which to log to the console in this demo app. Adjust this
 // to control how verbose the logging is.
@@ -42,7 +42,7 @@ finally
 
 async Task DriveBrowser(string webSocketUrl)
 {
-    Driver driver = new(new WebDriverBidi.Protocol.Transport(TimeSpan.FromSeconds(30)));
+    Driver driver = new();
     driver.LogMessage += OnDriverLogMessage;
     driver.BrowsingContext.NavigationStarted += (sender, e) =>
     {

--- a/src/WebDriverBidi.Demo/Program.cs
+++ b/src/WebDriverBidi.Demo/Program.cs
@@ -13,7 +13,7 @@ using WebDriverBidi.Session;
 // Path to the directory containing the browser launcher executables.
 // We use the WebDriver Classic browser drivers (chromedriver, geckodriver, etc.)
 // as browser launchers.
-string browserLauncherDirectory = string.Empty;
+string browserLauncherDirectory = "/Users/james.evans/Downloads";
 
 // The level at which to log to the console in this demo app. Adjust this
 // to control how verbose the logging is.
@@ -42,7 +42,7 @@ finally
 
 async Task DriveBrowser(string webSocketUrl)
 {
-    Driver driver = new();
+    Driver driver = new(new WebDriverBidi.Protocol.Transport(TimeSpan.FromSeconds(30)));
     driver.LogMessage += OnDriverLogMessage;
     driver.BrowsingContext.NavigationStarted += (sender, e) =>
     {

--- a/src/WebDriverBidi/BrowsingContext/NavigationEventArgs.cs
+++ b/src/WebDriverBidi/BrowsingContext/NavigationEventArgs.cs
@@ -79,7 +79,7 @@ public class NavigationEventArgs : WebDriverBidiEventArgs
         private set
         {
             this.epochTimestamp = value;
-            this.timestamp = DateTime.UnixEpoch.AddMilliseconds(value);
+            this.timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value);
         }
     }
 }

--- a/src/WebDriverBidi/BrowsingContext/NavigationEventArgs.cs
+++ b/src/WebDriverBidi/BrowsingContext/NavigationEventArgs.cs
@@ -6,6 +6,7 @@
 namespace WebDriverBidi.BrowsingContext;
 
 using Newtonsoft.Json;
+using WebDriverBidi.Internal;
 
 /// <summary>
 /// Object containing event data for events raised during navigation.
@@ -60,7 +61,7 @@ public class NavigationEventArgs : WebDriverBidiEventArgs
     public string Url { get => this.url; internal set => this.url = value; }
 
     /// <summary>
-    /// Gets the timestamp of the navigationin UTC.
+    /// Gets the timestamp of the navigation in UTC.
     /// </summary>
     public DateTime Timestamp => this.timestamp;
 
@@ -79,7 +80,7 @@ public class NavigationEventArgs : WebDriverBidiEventArgs
         private set
         {
             this.epochTimestamp = value;
-            this.timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value);
+            this.timestamp = DateTimeUtilities.UnixEpoch.AddMilliseconds(value);
         }
     }
 }

--- a/src/WebDriverBidi/Internal/DateTimeUtilities.cs
+++ b/src/WebDriverBidi/Internal/DateTimeUtilities.cs
@@ -1,0 +1,28 @@
+// <copyright file="DateTimeUtilities.cs" company="WebDriverBidi.NET Committers">
+// Copyright (c) WebDriverBidi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBidi.Internal;
+
+/// <summary>
+/// A utility class for System.DateTime values.
+/// </summary>
+/// <remarks>
+/// This class is intentionally marked as internal, as it only contains utility
+/// properties and methods used within this library. They should have little use
+/// for users outside of this library. Should that change, this class could be
+/// moved to another namespace and exposed for external use.
+/// </remarks>
+internal static class DateTimeUtilities
+{
+    /// <summary>
+    /// Gets a DateTime representing the start of the Unix epoch (1 January 1970 12:00 AM UTC).
+    /// </summary>
+    /// <remarks>
+    /// The DateTime struct introduces this property in .NET 5, but is unavailable for libraries
+    /// targeting .NET Standard 2.0. This property is provided to minimize mistakes in calculating
+    /// dates that are offsets from the Unix zero date.
+    /// </remarks>
+    public static DateTime UnixEpoch => new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+}

--- a/src/WebDriverBidi/JsonConverters/EnumValueJsonConverter.cs
+++ b/src/WebDriverBidi/JsonConverters/EnumValueJsonConverter.cs
@@ -25,7 +25,7 @@ public class EnumValueJsonConverter<T> : JsonConverter<T>
     public EnumValueJsonConverter()
     {
         Type enumType = typeof(T);
-        T[] values = Enum.GetValues<T>();
+        T[] values = (T[])Enum.GetValues(typeof(T));
 
         foreach (T value in values)
         {

--- a/src/WebDriverBidi/Log/LogEntry.cs
+++ b/src/WebDriverBidi/Log/LogEntry.cs
@@ -84,7 +84,7 @@ public class LogEntry
         private set
         {
             this.epochTimestamp = value;
-            this.timestamp = DateTime.UnixEpoch.AddMilliseconds(value);
+            this.timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value);
         }
     }
 }

--- a/src/WebDriverBidi/Log/LogEntry.cs
+++ b/src/WebDriverBidi/Log/LogEntry.cs
@@ -6,6 +6,7 @@
 namespace WebDriverBidi.Log;
 
 using Newtonsoft.Json;
+using WebDriverBidi.Internal;
 using WebDriverBidi.JsonConverters;
 using WebDriverBidi.Script;
 
@@ -84,7 +85,7 @@ public class LogEntry
         private set
         {
             this.epochTimestamp = value;
-            this.timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value);
+            this.timestamp = DateTimeUtilities.UnixEpoch.AddMilliseconds(value);
         }
     }
 }

--- a/src/WebDriverBidi/Network/BaseNetworkEventArgs.cs
+++ b/src/WebDriverBidi/Network/BaseNetworkEventArgs.cs
@@ -19,7 +19,7 @@ public class BaseNetworkEventArgs : WebDriverBidiEventArgs
     private ulong redirectCount = 0;
     private RequestData request = new();
     private ulong epochTimestamp = 0;
-    private DateTime timestamp = DateTime.UnixEpoch;
+    private DateTime timestamp = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     private List<string>? intercepts;
 
     /// <summary>
@@ -87,7 +87,7 @@ public class BaseNetworkEventArgs : WebDriverBidiEventArgs
         private set
         {
             this.epochTimestamp = value;
-            this.timestamp = DateTime.UnixEpoch.AddMilliseconds(value);
+            this.timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value);
         }
     }
 

--- a/src/WebDriverBidi/Network/BaseNetworkEventArgs.cs
+++ b/src/WebDriverBidi/Network/BaseNetworkEventArgs.cs
@@ -6,6 +6,7 @@
 namespace WebDriverBidi.Network;
 
 using Newtonsoft.Json;
+using WebDriverBidi.Internal;
 
 /// <summary>
 /// The base properties of all events for network traffic.
@@ -19,7 +20,7 @@ public class BaseNetworkEventArgs : WebDriverBidiEventArgs
     private ulong redirectCount = 0;
     private RequestData request = new();
     private ulong epochTimestamp = 0;
-    private DateTime timestamp = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private DateTime timestamp = DateTimeUtilities.UnixEpoch;
     private List<string>? intercepts;
 
     /// <summary>
@@ -87,7 +88,7 @@ public class BaseNetworkEventArgs : WebDriverBidiEventArgs
         private set
         {
             this.epochTimestamp = value;
-            this.timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value);
+            this.timestamp = DateTimeUtilities.UnixEpoch.AddMilliseconds(value);
         }
     }
 

--- a/src/WebDriverBidi/Network/Cookie.cs
+++ b/src/WebDriverBidi/Network/Cookie.cs
@@ -81,7 +81,7 @@ public class Cookie
             this.epochExpires = value;
             if (value.HasValue)
             {
-                this.expires = DateTime.UnixEpoch.AddMilliseconds(value.Value);
+                this.expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value.Value);
             }
         }
     }

--- a/src/WebDriverBidi/Network/Cookie.cs
+++ b/src/WebDriverBidi/Network/Cookie.cs
@@ -6,6 +6,7 @@
 namespace WebDriverBidi.Network;
 
 using Newtonsoft.Json;
+using WebDriverBidi.Internal;
 
 /// <summary>
 /// Represents a cookie in a web request or response.
@@ -81,7 +82,7 @@ public class Cookie
             this.epochExpires = value;
             if (value.HasValue)
             {
-                this.expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(value.Value);
+                this.expires = DateTimeUtilities.UnixEpoch.AddMilliseconds(value.Value);
             }
         }
     }

--- a/src/WebDriverBidi/WebDriverBidi.csproj
+++ b/src/WebDriverBidi/WebDriverBidi.csproj
@@ -1,18 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>11</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebDriverBidi.Tests/WebDriverBidi.Tests.csproj
+++ b/test/WebDriverBidi.Tests/WebDriverBidi.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="PinchHitter" Version="0.0.5" />
+    <PackageReference Include="PinchHitter" Version="0.0.7" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1">


### PR DESCRIPTION
Update this library to use .NET Standard 2.0 so as to maximize the reach of users. Targeting .NET Standard 2.0 allows the use of the library with the .NET Framework, as well as .NET Core and .NET 5.0+.