### PR TITLE
feat: Allow Transport to surface exceptions

### DIFF
--- a/src/WebDriverBiDi/Protocol/TransportErrorBehavior.cs
+++ b/src/WebDriverBiDi/Protocol/TransportErrorBehavior.cs
@@ -1,0 +1,30 @@
+// <copyright file="TransportErrorBehavior.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Protocol;
+
+/// <summary>
+/// The enumerated value specifying what the <see cref="Transport"/> should do upon encountering an error,
+/// such as a malformed JSON payload, an unexpected error response not caused by a command, or an unhandled
+/// exception in an event handler.
+/// </summary>
+public enum TransportErrorBehavior
+{
+    /// <summary>
+    /// Ignore errors.
+    /// </summary>
+    Ignore,
+
+    /// <summary>
+    /// Collect errors as they occur and throw an exception upon termination of the <see cref="Transport"/>.
+    /// </summary>
+    Collect,
+
+    /// <summary>
+    /// Terminates the <see cref="Transport"/> connection immediately. This will have the effect of throwing
+    /// an exception upon execution of the next command.
+    /// </summary>
+    Terminate,
+}

--- a/src/WebDriverBiDi/Protocol/UnhandledError.cs
+++ b/src/WebDriverBiDi/Protocol/UnhandledError.cs
@@ -1,0 +1,36 @@
+// <copyright file="UnhandledError.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Protocol;
+
+/// <summary>
+/// An unhandled error received during execution of transport functions.
+/// </summary>
+public class UnhandledError
+{
+    private UnhandledErrorType errorType;
+    private Exception exception;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnhandledError"/> class.
+    /// </summary>
+    /// <param name="errorType">The type of unhandled error.</param>
+    /// <param name="exception">The <see cref="Exception"/> to be thrown by the unhandled error.</param>
+    public UnhandledError(UnhandledErrorType errorType, Exception exception)
+    {
+        this.errorType = errorType;
+        this.exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the type of unhandled error.
+    /// </summary>
+    public UnhandledErrorType ErrorType => this.errorType;
+
+    /// <summary>
+    /// Gets the exception thrown by the unhandled error.
+    /// </summary>
+    public Exception Exception => this.exception;
+}

--- a/src/WebDriverBiDi/Protocol/UnhandledErrorCollection.cs
+++ b/src/WebDriverBiDi/Protocol/UnhandledErrorCollection.cs
@@ -1,0 +1,107 @@
+// <copyright file="UnhandledErrorCollection.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Protocol;
+
+/// <summary>
+/// The collection of unhandled errors in the protocol transport during execution of a WebDriver BiDi session.
+/// </summary>
+public class UnhandledErrorCollection
+{
+    private readonly List<UnhandledError> unhandledErrors = new();
+    private readonly Dictionary<UnhandledErrorType, TransportErrorBehavior> errorBehaviors = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnhandledErrorCollection"/> class.
+    /// </summary>
+    public UnhandledErrorCollection()
+    {
+        this.errorBehaviors[UnhandledErrorType.ProtocolError] = TransportErrorBehavior.Ignore;
+        this.errorBehaviors[UnhandledErrorType.UnknownMessage] = TransportErrorBehavior.Ignore;
+        this.errorBehaviors[UnhandledErrorType.UnexpectedError] = TransportErrorBehavior.Ignore;
+        this.errorBehaviors[UnhandledErrorType.EventHandlerException] = TransportErrorBehavior.Ignore;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating the behavior for errors resulting from an improper protocol message.
+    /// </summary>
+    public TransportErrorBehavior ProtocolErrorBehavior { get => this.errorBehaviors[UnhandledErrorType.ProtocolError]; set => this.errorBehaviors[UnhandledErrorType.ProtocolError] = value; }
+
+    /// <summary>
+    /// Gets or sets a value indicating the behavior for errors resulting from a valid JSON message that
+    /// corresponds to no defined protocol command response, error response, or event definition.
+    /// </summary>
+    public TransportErrorBehavior UnknownMessageBehavior { get => this.errorBehaviors[UnhandledErrorType.UnknownMessage]; set => this.errorBehaviors[UnhandledErrorType.UnknownMessage] = value; }
+
+    /// <summary>
+    /// Gets or sets a value indicating the behavior for errors resulting from valid error responses
+    /// that do not correspond to a command sent by the user.
+    /// </summary>
+    public TransportErrorBehavior UnexpectedErrorBehavior { get => this.errorBehaviors[UnhandledErrorType.UnexpectedError]; set => this.errorBehaviors[UnhandledErrorType.UnexpectedError] = value; }
+
+    /// <summary>
+    /// Gets or sets a value indicating the behavior for errors resulting from unhandled exceptions
+    /// in user-defined event handlers for protocol events.
+    /// </summary>
+    public TransportErrorBehavior EventHandlerExceptionBehavior { get => this.errorBehaviors[UnhandledErrorType.EventHandlerException]; set => this.errorBehaviors[UnhandledErrorType.EventHandlerException] = value; }
+
+    /// <summary>
+    /// Gets the list of exceptions for the unhandled errors in the collection.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when there are no unhandled errors in the collection.</exception>
+    public IList<Exception> Exceptions
+    {
+        get
+        {
+            if (this.unhandledErrors.Count == 0)
+            {
+                throw new InvalidOperationException("No unhandled errors.");
+            }
+
+            return this.unhandledErrors.Select(error => error.Exception).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Adds an unhandled error to the collection.
+    /// </summary>
+    /// <param name="errorType">The type of error to add.</param>
+    /// <param name="exception">The exception that causes the unhandled error.</param>
+    public void AddUnhandledError(UnhandledErrorType errorType, Exception exception)
+    {
+        if (this.errorBehaviors[errorType] == TransportErrorBehavior.Ignore)
+        {
+            return;
+        }
+
+        this.unhandledErrors.Add(new UnhandledError(errorType, exception));
+    }
+
+    /// <summary>
+    /// Clears the collection of unhandled errors.
+    /// </summary>
+    public void ClearUnhandledErrors()
+    {
+        this.unhandledErrors.Clear();
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the collection contains errors for the specified error behavior.
+    /// </summary>
+    /// <param name="errorBehavior">The error behavior for which to determine if errors exist.</param>
+    /// <returns><see langword="true"/> if the collection contains errors for the specified behavior; otherwise, <see langword="false"/>.</returns>
+    public bool HasUnhandledErrors(TransportErrorBehavior errorBehavior)
+    {
+        if (errorBehavior == TransportErrorBehavior.Ignore)
+        {
+            return false;
+        }
+
+        List<UnhandledErrorType> behaviors = this.errorBehaviors
+            .Where(pair => pair.Value == errorBehavior)
+            .Select(pair => pair.Key).ToList();
+        return this.unhandledErrors.Count(error => behaviors.Contains(error.ErrorType)) > 0;
+    }
+}

--- a/src/WebDriverBiDi/Protocol/UnhandledErrorType.cs
+++ b/src/WebDriverBiDi/Protocol/UnhandledErrorType.cs
@@ -1,0 +1,36 @@
+// <copyright file="UnhandledErrorType.cs" company="WebDriverBiDi.NET Committers">
+// Copyright (c) WebDriverBiDi.NET Committers. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace WebDriverBiDi.Protocol;
+
+/// <summary>
+/// The enumerated types of unhandled errors by the protocol transport.
+/// </summary>
+public enum UnhandledErrorType
+{
+    /// <summary>
+    /// An error resulting from an unparsable protocol message, for example,
+    /// invalid JSON, or JSON that does not contain required values.
+    /// </summary>
+    ProtocolError,
+
+    /// <summary>
+    /// An error resulting from a valid JSON protocol message, but which does
+    /// not match the schema of any known command result, error, or event.
+    /// </summary>
+    UnknownMessage,
+
+    /// <summary>
+    /// An error resulting from a valid JSON error response, but one that does
+    /// not correspond to a command that the user has sent.
+    /// </summary>
+    UnexpectedError,
+
+    /// <summary>
+    /// An error resulting from an unhandled exception in a user-defined event
+    /// handler for a protocol event.
+    /// </summary>
+    EventHandlerException,
+}

--- a/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
+++ b/test/WebDriverBiDi.Tests/BiDiDriverTests.cs
@@ -238,7 +238,7 @@ public class BiDiDriverTests
     }
 
     [Test]
-    public void TestDriverCanEmitLogMessagesFromProtocol()
+    public async Task TestDriverCanEmitLogMessagesFromProtocol()
     {
         DateTime testStart = DateTime.UtcNow;
         List<LogMessageEventArgs> logs = new();
@@ -249,6 +249,7 @@ public class BiDiDriverTests
         {
             logs.Add(e);
         };
+        await driver.StartAsync("ws:localhost");
         connection.RaiseLogMessageEvent("test log message", WebDriverBiDiLogLevel.Warn);
         Assert.That(logs, Has.Count.EqualTo(1));
         Assert.Multiple(() =>
@@ -290,25 +291,27 @@ public class BiDiDriverTests
     }
 
     [Test]
-    public void TestReceivingNullValueFromSendingCommandThrows()
+    public async Task TestReceivingNullValueFromSendingCommandThrows()
     {
         TestTransport transport = new(new TestConnection())
         {
             ReturnCustomValue = true
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await driver.StartAsync("ws:localhost");
         Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Result and thrown exception for command test.command with id 0 are both null"));
     }
 
     [Test]
-    public void TestExecutingCommandWillThrowWhenTimeout()
+    public async Task TestExecutingCommandWillThrowWhenTimeout()
     {
         BiDiDriver driver = new(TimeSpan.Zero, new Transport(new TestConnection()));
+        await driver.StartAsync("ws://localhost:5555");
         Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.Contains("Timed out executing command test.command"));
     }
 
     [Test]
-    public void TestReceivingInvalidErrorValueFromSendingCommandThrows()
+    public async Task TestReceivingInvalidErrorValueFromSendingCommandThrows()
     {
         TestCommandResult result = new();
         result.SetIsErrorValue(true);
@@ -318,11 +321,12 @@ public class BiDiDriverTests
             CustomReturnValue = result
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await driver.StartAsync("ws://localhost:5555");
         Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Could not convert error response from transport for SendCommandAndWait to ErrorResult"));
     }
 
     [Test]
-    public void TestReceivingInvalidResultTypeFromSendingCommandThrows()
+    public async Task TestReceivingInvalidResultTypeFromSendingCommandThrows()
     {
         TestCommandResultInvalid result = new();
         TestTransport transport = new(new TestConnection())
@@ -331,6 +335,7 @@ public class BiDiDriverTests
             CustomReturnValue = result
         };
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(250), transport);
+        await driver.StartAsync("ws://localhost:5555");
         Assert.That(async () => await driver.ExecuteCommandAsync<TestCommandResult>(new TestCommandParameters("test.command")), Throws.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("Could not convert response from transport for SendCommandAndWait to WebDriverBiDi.TestUtilities.TestCommandResult"));
     }
 

--- a/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Browser/BrowserModuleTests.cs
@@ -6,7 +6,7 @@ using TestUtilities;
 public class BrowserModuleTests
 {
     [Test]
-    public void TestExecuteCloseCommand()
+    public async Task TestExecuteCloseCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -16,6 +16,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowserModule module = new(driver);
 
         var task = module.CloseAsync(new CloseCommandParameters());
@@ -26,7 +27,7 @@ public class BrowserModuleTests
     }
 
     [Test]
-    public void TestExecuteCreateUserContextCommand()
+    public async Task TestExecuteCreateUserContextCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -36,6 +37,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowserModule module = new(driver);
 
         var task = module.CreateUserContextAsync(new CreateUserContextCommandParameters());
@@ -47,7 +49,7 @@ public class BrowserModuleTests
     }
 
     [Test]
-    public void TestExecuteGetUserContextsCommand()
+    public async Task TestExecuteGetUserContextsCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -57,6 +59,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowserModule module = new(driver);
 
         var task = module.GetUserContextsAsync(new GetUserContextsCommandParameters());
@@ -74,7 +77,7 @@ public class BrowserModuleTests
     }
 
     [Test]
-    public void TestExecuteRemoveUserContextCommand()
+    public async Task TestExecuteRemoveUserContextCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -84,6 +87,7 @@ public class BrowserModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowserModule module = new(driver);
 
         var task = module.RemoveUserContextAsync(new RemoveUserContextCommandParameters("myUserContextId"));

--- a/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/BrowsingContext/BrowsingContextModuleTests.cs
@@ -6,7 +6,7 @@ using TestUtilities;
 public class BrowsingContextModuleTests
 {
     [Test]
-    public void TestExecuteActivateCommand()
+    public async Task TestExecuteActivateCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -16,6 +16,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.ActivateAsync(new ActivateCommandParameters("myContextId"));
@@ -26,7 +27,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteCaptureScreenshotCommand()
+    public async Task TestExecuteCaptureScreenshotCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -36,6 +37,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.CaptureScreenshotAsync(new CaptureScreenshotCommandParameters("myContextId"));
@@ -47,7 +49,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteCloseCommand()
+    public async Task TestExecuteCloseCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -57,6 +59,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.CloseAsync(new CloseCommandParameters("myContextId"));
@@ -67,7 +70,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteCreateCommand()
+    public async Task TestExecuteCreateCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -77,6 +80,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.CreateAsync(new CreateCommandParameters(CreateType.Tab));
@@ -88,7 +92,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteGetTreeCommand()
+    public async Task TestExecuteGetTreeCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -98,6 +102,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.GetTreeAsync(new GetTreeCommandParameters());
@@ -115,7 +120,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteHandleUserPromptCommand()
+    public async Task TestExecuteHandleUserPromptCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -125,6 +130,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.HandleUserPromptAsync(new HandleUserPromptCommandParameters("myContextId"));
@@ -135,7 +141,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteLocateNodesCommand()
+    public async Task TestExecuteLocateNodesCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -145,6 +151,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.LocateNodesAsync(new LocateNodesCommandParameters("myContextId", new CssLocator(".selector")));
@@ -155,7 +162,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteNavigateCommand()
+    public async Task TestExecuteNavigateCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -165,6 +172,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.NavigateAsync(new NavigateCommandParameters("myContext", "https://example.com") { Wait = ReadinessState.Complete });
@@ -180,7 +188,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecutePrintCommand()
+    public async Task TestExecutePrintCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -190,6 +198,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.PrintAsync(new PrintCommandParameters("myContextId"));
@@ -201,7 +210,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteReloadCommand()
+    public async Task TestExecuteReloadCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -211,6 +220,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.ReloadAsync(new ReloadCommandParameters("myContext"));
@@ -226,7 +236,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteSetViewportCommand()
+    public async Task TestExecuteSetViewportCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -236,6 +246,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.SetViewportAsync(new SetViewportCommandParameters("myContextId"));
@@ -246,7 +257,7 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestExecuteTraverseHistoryCommand()
+    public async Task TestExecuteTraverseHistoryCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -256,6 +267,7 @@ public class BrowsingContextModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         var task = module.TraverseHistoryAsync(new TraverseHistoryCommandParameters("myContextId", -3));
@@ -266,10 +278,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveContextCreatedEvent()
+    public async Task TestCanReceiveContextCreatedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -291,10 +304,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveContextDestroyedEvent()
+    public async Task TestCanReceiveContextDestroyedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -316,10 +330,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveDomContentLoadedEvent()
+    public async Task TestCanReceiveDomContentLoadedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -343,10 +358,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveDownloadWillBeginEvent()
+    public async Task TestCanReceiveDownloadWillBeginEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -370,10 +386,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveFragmentNavigatedEvent()
+    public async Task TestCanReceiveFragmentNavigatedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -397,10 +414,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveLoadEvent()
+    public async Task TestCanReceiveLoadEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -424,10 +442,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveNavigationAbortedEvent()
+    public async Task TestCanReceiveNavigationAbortedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -451,10 +470,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveNavigationFailedEvent()
+    public async Task TestCanReceiveNavigationFailedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -478,10 +498,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveNavigationStartedEvent()
+    public async Task TestCanReceiveNavigationStartedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -505,10 +526,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveUserPromptClosedEvent()
+    public async Task TestCanReceiveUserPromptClosedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -529,10 +551,11 @@ public class BrowsingContextModuleTests
     }
 
     [Test]
-    public void TestCanReceiveUserPromptOpenedEvent()
+    public async Task TestCanReceiveUserPromptOpenedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         BrowsingContextModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);

--- a/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Input/InputModuleTests.cs
@@ -7,7 +7,7 @@ using WebDriverBiDi.TestUtilities;
 public class InputModuleTests
 {
     [Test]
-    public void TestExecutePerformActions()
+    public async Task TestExecutePerformActions()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -17,6 +17,7 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         InputModule module = new(driver);
 
         var task = module.PerformActionsAsync(new PerformActionsCommandParameters("myContextId"));
@@ -27,7 +28,7 @@ public class InputModuleTests
     }
 
     [Test]
-    public void TestExecuteReleaseActions()
+    public async Task TestExecuteReleaseActions()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -37,6 +38,7 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         InputModule module = new(driver);
 
         var task = module.ReleaseActionsAsync(new ReleaseActionsCommandParameters("myContextId"));
@@ -47,7 +49,7 @@ public class InputModuleTests
     }
 
     [Test]
-    public void TestExecuteSetFiles()
+    public async Task TestExecuteSetFiles()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -57,6 +59,7 @@ public class InputModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         InputModule module = new(driver);
 
         var element = new SharedReference("mySharedId");

--- a/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Network/NetworkModuleTests.cs
@@ -77,7 +77,7 @@ public class NetworkModuleTests
 }";
 
     [Test]
-    public void TestExecuteAddInterceptCommand()
+    public async Task TestExecuteAddInterceptCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -87,6 +87,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         AddInterceptCommandParameters commandParameters = new()
@@ -104,7 +105,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestExecuteContinueRequestCommand()
+    public async Task TestExecuteContinueRequestCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -114,6 +115,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         var task = module.ContinueRequestAsync(new ContinueRequestCommandParameters("requestId"));
@@ -125,7 +127,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestExecuteContinueResponseCommand()
+    public async Task TestExecuteContinueResponseCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -135,6 +137,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         var task = module.ContinueResponseAsync(new ContinueResponseCommandParameters("requestId"));
@@ -146,7 +149,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestExecuteContinueWithAuthCommand()
+    public async Task TestExecuteContinueWithAuthCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -156,6 +159,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         var task = module.ContinueWithAuthAsync(new ContinueWithAuthCommandParameters("requestId")
@@ -171,7 +175,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestExecuteFailRequestCommand()
+    public async Task TestExecuteFailRequestCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -181,6 +185,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         var task = module.FailRequestAsync(new FailRequestCommandParameters("requestId"));
@@ -192,7 +197,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestExecuteProvideResponseCommand()
+    public async Task TestExecuteProvideResponseCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -202,6 +207,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         var task = module.ProvideResponseAsync(new ProvideResponseCommandParameters("requestId"));
@@ -213,7 +219,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestExecuteRemoveInterceptCommand()
+    public async Task TestExecuteRemoveInterceptCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -223,6 +229,7 @@ public class NetworkModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         var task = module.RemoveInterceptAsync(new RemoveInterceptCommandParameters("interceptId"));
@@ -234,7 +241,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestCanReceiveAuthRequiredEvent()
+    public async Task TestCanReceiveAuthRequiredEvent()
     {
         DateTime now = DateTime.UtcNow;
         DateTime eventTime = new(now.Ticks - (now.Ticks % TimeSpan.TicksPerMillisecond));
@@ -242,6 +249,7 @@ public class NetworkModuleTests
 
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -312,7 +320,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestCanReceiveBeforeRequestSendEvent()
+    public async Task TestCanReceiveBeforeRequestSendEvent()
     {
         DateTime now = DateTime.UtcNow;
         DateTime eventTime = new(now.Ticks - (now.Ticks % TimeSpan.TicksPerMillisecond));
@@ -320,6 +328,7 @@ public class NetworkModuleTests
 
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -379,7 +388,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestCanReceiveFetchErrorEvent()
+    public async Task TestCanReceiveFetchErrorEvent()
     {
         DateTime now = DateTime.UtcNow;
         DateTime eventTime = new(now.Ticks - (now.Ticks % TimeSpan.TicksPerMillisecond));
@@ -387,6 +396,7 @@ public class NetworkModuleTests
 
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -444,7 +454,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestCanReceiveResponseStartedEvent()
+    public async Task TestCanReceiveResponseStartedEvent()
     {
         DateTime now = DateTime.UtcNow;
         DateTime eventTime = new(now.Ticks - (now.Ticks % TimeSpan.TicksPerMillisecond));
@@ -452,6 +462,7 @@ public class NetworkModuleTests
 
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);
@@ -522,7 +533,7 @@ public class NetworkModuleTests
     }
 
     [Test]
-    public void TestCanReceiveResponseCompletedEvent()
+    public async Task TestCanReceiveResponseCompletedEvent()
     {
         DateTime now = DateTime.UtcNow;
         DateTime eventTime = new(now.Ticks - (now.Ticks % TimeSpan.TicksPerMillisecond));
@@ -530,6 +541,7 @@ public class NetworkModuleTests
 
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         NetworkModule module = new(driver);
 
         ManualResetEvent syncEvent = new(false);

--- a/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Permissions/PermissionsModuleTests.cs
@@ -6,7 +6,7 @@ using TestUtilities;
 public class PermissionsModuleTests
 {
     [Test]
-    public void TestExecuteActivateCommand()
+    public async Task TestExecuteActivateCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -16,6 +16,7 @@ public class PermissionsModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
+        await driver.StartAsync("ws:localhost");
         PermissionsModule module = new(driver);
 
         var task = module.SetPermission(new SetPermissionCommandParameters("myPermission", PermissionState.Granted, "https://example.com"));

--- a/test/WebDriverBiDi.Tests/Protocol/UnhandledErrorCollectionTests.cs
+++ b/test/WebDriverBiDi.Tests/Protocol/UnhandledErrorCollectionTests.cs
@@ -1,0 +1,125 @@
+namespace WebDriverBiDi.Protocol;
+
+[TestFixture]
+public class UnhandledErrorCollectionTests()
+{
+    [Test]
+    public void TestDefaultPropertyValues()
+    {
+        UnhandledErrorCollection unhandledErrors = new();
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.ProtocolErrorBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+            Assert.That(unhandledErrors.UnexpectedErrorBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+            Assert.That(unhandledErrors.UnknownMessageBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+            Assert.That(unhandledErrors.EventHandlerExceptionBehavior, Is.EqualTo(TransportErrorBehavior.Ignore));
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
+            Assert.That(() => unhandledErrors.Exceptions, Throws.InstanceOf<InvalidOperationException>().With.Message.EqualTo("No unhandled errors."));
+        });
+    }
+
+    [Test]
+    public void TestAddingUnhandledErrorWithIgnoreDoesNotAddErrorToCollection()
+    {
+        UnhandledErrorCollection unhandledErrors = new();
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
+        });
+    }
+
+    [Test]
+    public void TestAddingUnhandledErrorWithCollect()
+    {
+        UnhandledErrorCollection unhandledErrors = new()
+        {
+            ProtocolErrorBehavior = TransportErrorBehavior.Collect
+        };
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
+        });
+    }
+
+    [Test]
+    public void TestAddingUnhandledErrorWithTerminate()
+    {
+        UnhandledErrorCollection unhandledErrors = new()
+        {
+            ProtocolErrorBehavior = TransportErrorBehavior.Terminate
+        };
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.True);
+        });
+    }
+
+
+    [Test]
+    public void TestClearingUnhandledErrors()
+    {
+        UnhandledErrorCollection unhandledErrors = new()
+        {
+            ProtocolErrorBehavior = TransportErrorBehavior.Collect
+        };
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
+        });
+        unhandledErrors.ClearUnhandledErrors();
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.False);
+        });
+    }
+
+    [Test]
+    public void TestCanGetExceptions()
+    {
+        UnhandledErrorCollection unhandledErrors = new()
+        {
+            ProtocolErrorBehavior = TransportErrorBehavior.Collect
+        };
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("new exception"));
+        Assert.That(unhandledErrors.Exceptions, Has.Count.EqualTo(1));
+        Assert.That(unhandledErrors.Exceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("new exception"));
+    }
+
+    [Test]
+    public void TestCanCaptureErrorsForDifferentBehaviorTypes()
+    {
+        UnhandledErrorCollection unhandledErrors = new()
+        {
+            ProtocolErrorBehavior = TransportErrorBehavior.Collect,
+            UnexpectedErrorBehavior = TransportErrorBehavior.Terminate
+        };
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.ProtocolError, new WebDriverBiDiException("invalid protocol message"));
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.UnexpectedError, new WebDriverBiDiException("unexpected error"));
+        unhandledErrors.AddUnhandledError(UnhandledErrorType.EventHandlerException, new WebDriverBiDiException("event handler"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Ignore), Is.False);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Collect), Is.True);
+            Assert.That(unhandledErrors.HasUnhandledErrors(TransportErrorBehavior.Terminate), Is.True);
+            Assert.That(unhandledErrors.Exceptions, Has.Count.EqualTo(2));
+            Assert.That(unhandledErrors.Exceptions[0], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("invalid protocol message"));
+            Assert.That(unhandledErrors.Exceptions[1], Is.InstanceOf<WebDriverBiDiException>().With.Message.EqualTo("unexpected error"));
+        });
+    }
+}

--- a/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Script/ScriptModuleTests.cs
@@ -7,7 +7,7 @@ using WebDriverBiDi.Protocol;
 public class ScriptModuleTests
 {
     [Test]
-    public void TestExecuteCallFunctionCommand()
+    public async Task TestExecuteCallFunctionCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -18,6 +18,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.CallFunctionAsync(new CallFunctionCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
         task.Wait(TimeSpan.FromSeconds(1));
@@ -40,7 +41,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestExecuteCallFunctionCommandReturningError()
+    public async Task TestExecuteCallFunctionCommandReturningError()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -51,6 +52,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.CallFunctionAsync(new CallFunctionCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
         task.Wait(TimeSpan.FromSeconds(1));
@@ -76,7 +78,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestExecuteEvaluateCommand()
+    public async Task TestExecuteEvaluateCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -87,6 +89,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
         
         var task = module.EvaluateAsync(new EvaluateCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
         task.Wait(TimeSpan.FromSeconds(1));
@@ -109,7 +112,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestExecuteEvaluateCommandReturningError()
+    public async Task TestExecuteEvaluateCommandReturningError()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -120,6 +123,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.EvaluateAsync(new EvaluateCommandParameters("myFunction() {}", new ContextTarget("myContextId"), true));
         task.Wait(TimeSpan.FromSeconds(1));
@@ -145,7 +149,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestExecuteGetRealmsCommand()
+    public async Task TestExecuteGetRealmsCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -156,6 +160,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.GetRealmsAsync(new GetRealmsCommandParameters());
         task.Wait(TimeSpan.FromSeconds(1));
@@ -179,7 +184,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestExecuteDisownCommand()
+    public async Task TestExecuteDisownCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -190,6 +195,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.DisownAsync(new DisownCommandParameters(new ContextTarget("myContextId"), new string[] { "myValue" }));
         task.Wait(TimeSpan.FromSeconds(1));
@@ -200,11 +206,12 @@ public class ScriptModuleTests
    }
 
     [Test]
-    public void TestCanReceiveRealmCreatedEvent()
+    public async Task TestCanReceiveRealmCreatedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         ManualResetEvent syncEvent = new(false);
         module.RealmCreated += (object? obj, RealmCreatedEventArgs e) => {
@@ -225,11 +232,12 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestCanReceiveRealmCreatedEventForNonWindowRealm()
+    public async Task TestCanReceiveRealmCreatedEventForNonWindowRealm()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         ManualResetEvent syncEvent = new(false);
         module.RealmCreated += (object? obj, RealmCreatedEventArgs e) => {
@@ -250,11 +258,12 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestCanReceiveRealmDestroyedEvent()
+    public async Task TestCanReceiveRealmDestroyedEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         ManualResetEvent syncEvent = new(false);
         module.RealmDestroyed += (object? obj, RealmDestroyedEventArgs e) =>
@@ -270,11 +279,12 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestCanReceiveMessageEvent()
+    public async Task TestCanReceiveMessageEvent()
     {
         TestConnection connection = new();
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         ManualResetEvent syncEvent = new(false);
         module.Message += (object? obj, MessageEventArgs e) => {
@@ -297,7 +307,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestCanAddPreloadScript()
+    public async Task TestCanAddPreloadScript()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -308,6 +318,8 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
+
         var task = module.AddPreloadScriptAsync(new AddPreloadScriptCommandParameters("window.foo = false;"));
         task.Wait(TimeSpan.FromSeconds(1));
         var result = task.Result;
@@ -318,7 +330,7 @@ public class ScriptModuleTests
     }
 
     [Test]
-    public void TestCanRemovePreloadScript()
+    public async Task TestCanRemovePreloadScript()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -329,6 +341,7 @@ public class ScriptModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         ScriptModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
         
         var task = module.RemovePreloadScriptAsync(new RemovePreloadScriptCommandParameters("loadScriptId"));
         task.Wait(TimeSpan.FromSeconds(1));

--- a/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Session/SessionModuleTests.cs
@@ -7,7 +7,7 @@ using WebDriverBiDi.Protocol;
 public class SessionModuleTests
 {
     [Test]
-    public void TestExecuteStatusCommand()
+    public async Task TestExecuteStatusCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -17,7 +17,10 @@ public class SessionModuleTests
         };
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
-        var task = driver.Session.StatusAsync(new StatusCommandParameters());
+        SessionModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
+
+        var task = module.StatusAsync(new StatusCommandParameters());
         task.Wait(TimeSpan.FromSeconds(1));
         var result = task.Result;
 
@@ -30,7 +33,7 @@ public class SessionModuleTests
     }
 
     [Test]
-    public void TestExecuteSubscribeCommand()
+    public async Task TestExecuteSubscribeCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -41,6 +44,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var subscribeParameters = new SubscribeCommandParameters();
         subscribeParameters.Events.Add("log.entryAdded");
@@ -52,7 +56,7 @@ public class SessionModuleTests
     }
 
     [Test]
-    public void TestExecuteUnsubscribeCommand()
+    public async Task TestExecuteUnsubscribeCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -63,6 +67,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var unsubscribeParameters = new UnsubscribeCommandParameters();
         unsubscribeParameters.Events.Add("log.entryAdded");
@@ -74,7 +79,7 @@ public class SessionModuleTests
     }
 
     [Test]
-    public void TestExecuteNewCommand()
+    public async Task TestExecuteNewCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -85,6 +90,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var newCommandParameters = new NewCommandParameters();
         var task = module.NewSessionAsync(newCommandParameters);
@@ -111,7 +117,7 @@ public class SessionModuleTests
     }
 
     [Test]
-    public void TestExecuteEndCommand()
+    public async Task TestExecuteEndCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -122,6 +128,7 @@ public class SessionModuleTests
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new(connection));
         SessionModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var endParameters = new EndCommandParameters();
         var task = module.EndAsync(endParameters);

--- a/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
+++ b/test/WebDriverBiDi.Tests/Storage/StorageModuleTests.cs
@@ -8,7 +8,7 @@ using WebDriverBiDi.TestUtilities;
 public class StorageModuleTests()
 {
     [Test]
-    public void TestGetCookiesCommand()
+    public async Task TestGetCookiesCommand()
     {
         DateTime now = DateTime.UtcNow.AddSeconds(10);
         DateTime expireTime = new(now.Ticks - (now.Ticks % TimeSpan.TicksPerMillisecond));
@@ -22,6 +22,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.GetCookiesAsync(new GetCookiesCommandParameters());
         task.Wait(TimeSpan.FromSeconds(1));
@@ -47,7 +48,7 @@ public class StorageModuleTests()
     }
 
     [Test]
-    public void TestSetCookieCommand()
+    public async Task TestSetCookieCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -58,6 +59,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.SetCookieAsync(new SetCookieCommandParameters(new PartialCookie("cookieName", BytesValue.FromString("cookieValue"), "cookieDomain")));
         task.Wait(TimeSpan.FromSeconds(1));
@@ -72,7 +74,7 @@ public class StorageModuleTests()
     }
 
     [Test]
-    public void TestDeleteCookiesCommand()
+    public async Task TestDeleteCookiesCommand()
     {
         TestConnection connection = new();
         connection.DataSendComplete += (sender, e) =>
@@ -83,6 +85,7 @@ public class StorageModuleTests()
 
         BiDiDriver driver = new(TimeSpan.FromMilliseconds(500), new Transport(connection));
         StorageModule module = new(driver);
+        await driver.StartAsync("ws:localhost");
 
         var task = module.DeleteCookiesAsync(new DeleteCookiesCommandParameters());
         task.Wait(TimeSpan.FromSeconds(1));


### PR DESCRIPTION
Since the Transport is running async code, exceptions encountered by event handlers will be silently swallowed. To be precise, they are raised on the synchonization context of a different thread than the user's thread. This change allows those exceptions to be surfaced to the user, and for the user to specify when those exceptions are propagated (never; at shutdown; or as soon as possible, usually when the user attempts to execute the next command)